### PR TITLE
BOO-2075: Fix playback speed being reset on .seek/HLS bitrate change

### DIFF
--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -96,7 +96,7 @@ static void *rateContext = &rateContext;
             context:playbackBufferFullContext];
   [_player addObserver:self
          forKeyPath:@"rate"
-            options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
+            options:NSKeyValueObservingOptionNew
             context:rateContext];
 
   // Add an observer that will respond to itemDidPlayToEndTime
@@ -301,7 +301,7 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
       _eventSink(@{@"event" : @"bufferingEnd"});
     }
   } else if (context == rateContext) {
-    if (_isInitialized && _isPlaying && _player.rate != _internalPlaybackSpeed && _player.rate != 0.0) {
+    if (_isPlaying && _player.rate != 0.0 && _player.rate != _internalPlaybackSpeed) {
       // AVPlayer's rate gets reset on HLS bitrate changes, and also on .seek calls
       // So we listen to rate changes, and then force the playback rate back to our intended rate
       // In some rare cases this causes a very small audio hiccup,

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -43,6 +43,7 @@
 @property(nonatomic, readonly) BOOL disposed;
 @property(nonatomic, readonly) BOOL isPlaying;
 @property(nonatomic) BOOL isLooping;
+@property(nonatomic) double internalPlaybackSpeed;
 @property(nonatomic, readonly) BOOL isInitialized;
 - (instancetype)initWithURL:(NSURL *)url
                frameUpdater:(FLTFrameUpdater *)frameUpdater
@@ -56,6 +57,7 @@ static void *durationContext = &durationContext;
 static void *playbackLikelyToKeepUpContext = &playbackLikelyToKeepUpContext;
 static void *playbackBufferEmptyContext = &playbackBufferEmptyContext;
 static void *playbackBufferFullContext = &playbackBufferFullContext;
+static void *rateContext = &rateContext;
 
 @implementation FLTVideoPlayer
 - (instancetype)initWithAsset:(NSString *)asset frameUpdater:(FLTFrameUpdater *)frameUpdater {
@@ -92,6 +94,10 @@ static void *playbackBufferFullContext = &playbackBufferFullContext;
          forKeyPath:@"playbackBufferFull"
             options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
             context:playbackBufferFullContext];
+  [_player addObserver:self
+         forKeyPath:@"rate"
+            options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
+            context:rateContext];
 
   // Add an observer that will respond to itemDidPlayToEndTime
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -294,6 +300,15 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
     if (_eventSink != nil) {
       _eventSink(@{@"event" : @"bufferingEnd"});
     }
+  } else if (context == rateContext) {
+    if (_isInitialized && _isPlaying && _player.rate != _internalPlaybackSpeed && _player.rate != 0.0) {
+      // AVPlayer's rate gets reset on HLS bitrate changes, and also on .seek calls
+      // So we listen to rate changes, and then force the playback rate back to our intended rate
+      // In some rare cases this causes a very small audio hiccup,
+      // but there seems to be no better solution at this time
+      // See: https://github.com/flutter/flutter/issues/71264
+      [self setPlaybackSpeed:_internalPlaybackSpeed];
+    }
   }
 }
 
@@ -418,6 +433,7 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
     return;
   }
 
+  [self setInternalPlaybackSpeed:speed];
   _player.rate = speed;
 }
 


### PR DESCRIPTION
объединил подходы из [react-native-video](https://github.com/alexfoxy/react-native-video/blob/master/ios/RCTVideo.m) и [flutter-plugins proposed pr](https://github.com/alexagat/plugins/blob/9563754fa3cd9fbdece49e58c087583f96d76d83/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m)

и немного в [Google Ads Media Framework](https://github.com/googleads/google-media-framework-ios/blob/main/GoogleMediaFramework/GMFVideoPlayer.m) подсмотрел

`rate` может как угодно произольно прыгать (например при малейшей подгрузке он сам станет 0, а потом вернется к 1)

ну и `.seek` тоже как мы помним сбрасывает `rate`

есть клёвый колбек на это `rateDidChangeNotification`, но он появился только с iOS 15, нам не подходит: https://developer.apple.com/documentation/avfoundation/avplayer/3746584-ratedidchangenotification

поэтому использую [KVO](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/KeyValueObserving/Articles/KVOBasics.html#//apple_ref/doc/uid/20002252-BAJEAIEE) - проперти [rate](https://developer.apple.com/documentation/avfoundation/avplayer/1388846-rate). слушаю изменения во время плейбека - и если там что-то поменялось - то форсирую заново нашу скорость

если будут раздражать небольшие пролаги аудио при переключении дорожек битрейта (это вообще норм - в ютубе тоже он есть) - можно будет потом уменьшить чувствительность переключали качеств, чтобы он реже скакал туда сюда. ну и импрув кеширования тоже явно поможет 